### PR TITLE
fix DesktopMap setZoomState infinite update

### DIFF
--- a/scatter/next-app/.gitignore
+++ b/scatter/next-app/.gitignore
@@ -35,3 +35,5 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# IDE
+.idea

--- a/scatter/next-app/components/DesktopMap.tsx
+++ b/scatter/next-app/components/DesktopMap.tsx
@@ -303,8 +303,12 @@ function DesktopMap(props: MapProps) {
     }
     const x = (containerWidth - (dataWidth * scale)) / 2 - (minX * scale);
     const y = (containerHeight - (dataHeight * scale)) / 2 - (minY * scale);
-  
-    setZoomState({ scale, x, y });
+
+    // zoomState が変更される場合のみ setZoomState を呼び出す
+    if (zoomState.scale !== scale || zoomState.x !== x || zoomState.y !== y) {
+      setZoomState({ scale, x, y });
+    }
+
   }, [clusters, dimensions, fullScreen]);
 
   const map_title = extractFirstBracketContent(config.name);


### PR DESCRIPTION
DesktopMap.tsx が重いらしいとのことで調査

useEffect 内で setZoomState が常に呼ばれており、これが無限ループを起こしているように見えた
差分があるときのみ zoomState を更新するように修正した
（軽量化への影響がどれほどかは検証してないが、幾分マシになると思われる）