### PR TITLE
implement LLM based classification in extraction

### DIFF
--- a/scatter/README.md
+++ b/scatter/README.md
@@ -160,6 +160,13 @@ extraction?: {
   limit?: number // maximal number of rows to process (default to 1000)
   workers?: number // maximal number of parallel workers (default to 1)
   properties?: string[] // list of properties to extract from the input file (default to []). extracted properties will be added to the output file.
+   categories?: { 
+    [key: string]: { // Name of the category group (e.g., "sentiment", "genre")
+      [key: string]: string // Name and description of each category
+    }
+  } // Definition of categories to be assigned to comments. Keys are category group names, and values are objects describing each category. If categories are defined, LLM will be used for category classification.
+  category_batch_size?: number // Number of comments to classify in one batch process (default is 5)
+
 },
 clustering: {
   clusters?: number // number of clusters to generate (default to 8)

--- a/scatter/README_ja.md
+++ b/scatter/README_ja.md
@@ -136,6 +136,12 @@ open http://localhost:8080/pipeline/outputs/my-project/report/
     limit?: number // 処理する行の最大数（デフォルトは1000）
     workers?: number // 並行ワーカーの最大数（デフォルトは1）
     properties?: string[] // 抽出するプロパティのリスト（デフォルトは[]）。抽出されたプロパティは出力ファイルに追加されます。
+    categories?: { 
+      [key: string]: { // カテゴリのグループ名 (例: "sentiment", "genre")
+        [key: string]: string // 各カテゴリの名前とその説明
+      }
+    } // argsに付与するカテゴリの定義。キーはカテゴリグループ名、値は各カテゴリの説明のオブジェクト。categoriesが存在する場合はLLMを用いたカテゴリ分類がextraction内部で実行される。
+    category_batch_size?: number // 一度のバッチ処理で分類するコメントの数 (デフォルトは5)
   },
   clustering: {
     clusters?: number // 生成するクラスターの数（デフォルトは8）

--- a/scatter/pipeline/configs/dummy-comments-japan.json
+++ b/scatter/pipeline/configs/dummy-comments-japan.json
@@ -9,7 +9,25 @@
       "properties":[
         "source",
         "age"
-      ]
+      ],
+      "categories": {
+        "sentiment": {
+          "positive": "肯定的な意見につけるカテゴリ",
+          "negative": "否定的な意見につけるカテゴリ",
+          "neutral": "中立的な意見につけるカテゴリ"
+        },
+        "genre":{
+          "politics": "政治に関する意見",
+          "economy": "経済に関する意見",
+          "society": "社会に関する意見",
+          "environment": "環境に関する意見",
+          "education": "教育に関する意見",
+          "health": "健康に関する意見",
+          "culture": "文化に関する意見",
+          "others": "その他"
+        }
+      },
+      "category_batch_size": 5
     },
     "clustering": {
       "clusters": 3

--- a/scatter/pipeline/services/category_classification.py
+++ b/scatter/pipeline/services/category_classification.py
@@ -1,0 +1,157 @@
+import concurrent.futures
+import json
+
+import pandas as pd
+from tqdm import tqdm
+
+from services.llm import request_to_openai
+
+BASE_CLASSIFICATION_PROMPT = """与えられた意見群をカテゴリに分類してください
+
+# 前提・指示
+* 意見は複数与えられることがあります
+* 分類対象のカテゴリは複数与えられることがあります
+* 前述の前提を踏まえて、出力例に記載したフォーマットでjsonを出力してください
+
+# 分類対象のカテゴリ
+{categories_string}
+
+# 出力例
+{{
+    "arg-id-1": {{
+        "sentiment": "positive",
+        "genre": "politics",
+    }},
+    "arg-id-2": {{
+        "sentiment": "negative",
+        "genre": "economy",
+    }}
+}}
+
+
+# 分類する意見（id: 内容を記載）
+{args_string}
+"""
+
+# 構築されるプロンプトの例
+# """与えられた意見群をカテゴリに分類してください
+
+# # 前提・指示
+# * 意見は複数与えられることがあります
+# * 分類対象のカテゴリは複数与えられることがあります
+# * 前述の前提を踏まえて、出力例に記載したフォーマットでjsonを出力してください
+
+# # 分類対象のカテゴリ
+# それぞれのカテゴリに対して一つづつカテゴリを割り当ててください
+
+# ## カテゴリ: sentiment
+# - ポジティブ: 肯定的な意見につけるカテゴリ
+# - ネガティブ: 否定的な意見につけるカテゴリ
+# - ニュートラル: 中立的な意見につけるカテゴリ
+
+# ## カテゴリ: genre
+# - 政治: 政治に関する意見
+# - 経済: 経済に関する意見
+# - 社会: 社会に関する意見
+# - 環境: 環境に関する意見
+# - 教育: 教育に関する意見
+# - 健康: 健康に関する意見
+# - 文化: 文化に関する意見
+# - その他: その他
+
+# # 出力例
+# {{
+#     "arg-id-1": {{
+#         "sentiment": "positive",
+#         "genre": "politics",
+#     }},
+#     "arg-id-2": {{
+#         "sentiment": "negative",
+#         "genre": "economy",
+#     }}
+# }}
+
+
+# # 分類する意見（id: 内容を記載）
+# - arg-1: 未来の日本では教育に投資してほしい
+# - arg-2: 未来の日本では環境に投資してほしい
+# """
+
+
+def _build_categories_string(categories: dict[str, dict[str, str]]) -> str:
+    result_string = ""
+    for category_type, category_description_dict in categories.items():
+        result_string += f"## カテゴリ「{category_type}」の分類先\n"
+        for category_description in category_description_dict.items():
+            result_string += f"- {category_description}\n"
+    return result_string
+
+
+def _build_batch_args_string(batch_args: pd.DataFrame) -> str:
+    return "\n".join(
+        [
+            f"- {arg_id}: {argument}"
+            for arg_id, argument in zip(batch_args["arg-id"], batch_args["argument"])
+        ]
+    )
+
+
+def classify_batch_args(batch_args: pd.DataFrame, categories: dict, model: str) -> dict:
+    category_string = _build_categories_string(categories)
+    batch_args_string = _build_batch_args_string(batch_args)
+    prompt = BASE_CLASSIFICATION_PROMPT.format(
+        categories_string=category_string, args_string=batch_args_string
+    )
+    result = request_to_openai(
+        messages=[
+            {"role": "system", "content": prompt},
+        ],
+        model=model,
+        is_json=True,
+    )
+    try:
+        return json.loads(result)
+    except json.JSONDecodeError:
+        return {}
+
+
+def process_batch(batch_args, config):
+    categories = config["extraction"]["categories"]
+    return classify_batch_args(batch_args, categories, config["extraction"]["model"])
+
+
+def classify_args(args: pd.DataFrame, config, workers: int) -> pd.DataFrame:
+    batch_size = config["extraction"]["category_batch_size"]
+
+    classification_results = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        # Adjust the range to ensure all elements are covered
+        batch_start_indices = range(0, len(args), batch_size)
+        future_to_batch = {
+            executor.submit(
+                classify_batch_args,
+                args.loc[batch_idx : batch_idx + batch_size],
+                config["extraction"]["categories"],
+                "gpt-4o-mini",
+                # config["extraction"]["model"]
+            ): batch_idx
+            for batch_idx in tqdm(batch_start_indices, desc="Classifying arguments")
+        }
+        for future in concurrent.futures.as_completed(future_to_batch):
+            result = future.result()
+            classification_results.update(result)
+
+    # 結果をdataframeに変換し、argsにjoinする
+    results = []
+    categories = list(config["extraction"]["categories"].keys())
+    for arg_id in args["arg-id"]:
+        arg_result = classification_results.get(arg_id, {})
+        results.append(
+            {
+                "arg-id": arg_id,
+                **{category: arg_result.get(category) for category in categories},
+            }
+        )
+    classification_results_df = pd.DataFrame(results)
+    merged = args.merge(classification_results_df, on="arg-id", how="left")
+    return merged

--- a/scatter/pipeline/specs.json
+++ b/scatter/pipeline/specs.json
@@ -9,7 +9,9 @@
     "options": {
       "limit": 1000,
       "workers": 1,
-      "properties": []
+      "properties": [],
+      "categories": {},
+      "category_batch_size": 5
     },
     "use_llm": true
   },

--- a/scatter/pipeline/steps/aggregation.py
+++ b/scatter/pipeline/steps/aggregation.py
@@ -53,7 +53,7 @@ def _build_property_map(
     property_map = defaultdict(dict)
     for prop in property_columns:
         for arg_id, row in arguments.iterrows():
-            # LLMによるclassificationがうまく行かず、NaNの場合はNoneにする
+            # LLMによるcategory classificationがうまく行かず、NaNの場合はNoneにする
             property_map[prop][arg_id] = row[prop] if not pd.isna(row[prop]) else None
     return property_map
 
@@ -202,8 +202,7 @@ def aggregation(config):
     property_columns = list(hidden_properties_map.keys()) + list(
         config["extraction"]["categories"].keys()
     )
-    property_map = _build_property_map(arguments, property_columns)
-    results["propertyMap"] = property_map
+    results["propertyMap"] = _build_property_map(arguments, property_columns)
 
     with open(path, "w") as file:
         json.dump(results, file, indent=2)


### PR DESCRIPTION
# 背景
https://github.com/takahiroanno2024/anno-broadlistening/issues/12

# 実装内容
* 設定ファイル内で定義されたカテゴリ体系に基づいて、LLMでargsを分類する機能を実装
  * 分類結果は属性として
  * 分類はextraction内部で実行される。extractionの設定ファイル内で `categories` が存在する場合のみ分類が実行される。
  * カテゴリ体系は複数定義することができる。
  * LLMによるカテゴリ分類がうまくいかなかった場合は、属性値がnullとなる
