### PR TITLE
Fixes #7 - visible raw comment data

### DIFF
--- a/scatter/next-app/components/DesktopTooltip.tsx
+++ b/scatter/next-app/components/DesktopTooltip.tsx
@@ -62,6 +62,7 @@ function Tooltip(props: TooltipProps) {
       pointerEvents: 'none', // ホバリング時はマウスイベントを無視
     }
 
+
   return (
     <>
       {(expanded) && (
@@ -104,6 +105,12 @@ function Tooltip(props: TooltipProps) {
           </button>
         </div>
         <p className="text-sm sm:text-sm md:text-md mt-2">{point.argument}</p>
+        {expanded && point.comment && (
+          <div className="mt-4 pt-4 border-t">
+            <p className="text-sm sm:text-sm md:text-sm">要約元のコメント</p>
+            <p className="text-xs sm:text-xs md:text-xs">{point.comment}</p>
+          </div>
+        )}
       </div>
     </>
   )


### PR DESCRIPTION
#7 元データがある場合は表示する対応です

<img width="558" alt="Screenshot 2024-12-19 at 17 33 48" src="https://github.com/user-attachments/assets/5a9e79ad-5cfd-4bee-9f05-527dbb538f08" />

表示条件
- point に comment データが存在する
- expanded が true である
- Desktop である
  - Mobile のほうは非対応、おそらく別対応したほうがよさそう？
  - 