### PR TITLE
add multi-labeling example and fix classification prompt

### DIFF
--- a/scatter/.gitignore
+++ b/scatter/.gitignore
@@ -10,6 +10,7 @@ pipeline/configs/*
 !pipeline/configs/example-polis.json
 !pipeline/configs/example-videos.json
 !pipeline/configs/dummy-comments-japan.json
+!pipeline/configs/dummy-comments-japan-multi.json
 pipeline/outputs/*
 pipeline/outputs/*/*.csv
 pipeline/outputs/*/*.pkl

--- a/scatter/pipeline/configs/dummy-comments-japan-multi.json
+++ b/scatter/pipeline/configs/dummy-comments-japan-multi.json
@@ -1,0 +1,40 @@
+{
+    "name": "日本の未来について",
+    "question": "日本の未来に対してどんな意見が寄せられているのか？",
+    "input": "dummy-comments-japan",
+    "model": "gpt-4o-mini",
+    "extraction": {
+      "workers": 3,
+      "limit": 20,
+      "properties":[
+        "source",
+        "age"
+      ],
+      "categories": {
+        "政治": {
+          "◯": "政治について言及している場合につける",
+          "×": "政治について言及していない場合につける"
+        },
+        "経済":{
+          "◯": "経済について言及している場合につける",
+          "×": "経済について言及していない場合につける"
+        }
+      },
+      "category_batch_size": 5
+    },
+    "clustering": {
+      "clusters": 3
+    },
+    "aggregation": {
+      "hidden_properties": {
+        "source": [
+          "X API"
+        ],
+        "age": [
+          20,
+          25
+        ]
+      }
+    },
+    "intro": "このAI生成レポートは、LLMによって生成されたダミーデータに対して分析を行っています。"
+  }

--- a/scatter/pipeline/services/category_classification.py
+++ b/scatter/pipeline/services/category_classification.py
@@ -19,12 +19,12 @@ BASE_CLASSIFICATION_PROMPT = """与えられた意見群をカテゴリに分類
 # 出力例
 {{
     "arg-id-1": {{
-        "sentiment": "positive",
-        "genre": "politics",
+        "カテゴリ1": "カテゴリ1の分類結果",
+        "カテゴリ2": "カテゴリ2の分類結果",
     }},
     "arg-id-2": {{
-        "sentiment": "negative",
-        "genre": "economy",
+        "カテゴリ1": "カテゴリ1の分類結果",
+        "カテゴリ2": "カテゴリ2の分類結果",
     }}
 }}
 
@@ -97,6 +97,9 @@ def _build_batch_args_string(batch_args: pd.DataFrame) -> str:
 
 
 def _parse_arg_result(classification_results: dict, arg_id: str, categories: list[str]) -> dict:
+    def is_valid_category_value(category_value: str) -> bool:
+        return isinstance(category_value, str) or isinstance(category_value, bool)
+
     arg_result = classification_results.get(arg_id, {})
     if not isinstance(arg_result, dict):
         return {
@@ -108,7 +111,7 @@ def _parse_arg_result(classification_results: dict, arg_id: str, categories: lis
     for category in categories:
         category_value = arg_result.get(category, None)
         # カテゴリの値はstrのみを想定（2024/12/19時点）
-        parsed_result[category] = category_value if isinstance(category_value, str) else None
+        parsed_result[category] = category_value if is_valid_category_value(category_value) else None
     return parsed_result
 
 


### PR DESCRIPTION
# 実装内容
* カテゴリ分類プロンプトの出力例を修正
  * 例に記載したフォーマットに引っ張られて、所望のフォーマットで出力できないケースがあったため
* multi-labelling ライクな分類を行う例を追加