### PR TITLE
Add embedding model options to embedding step

### DIFF
--- a/scatter/README.md
+++ b/scatter/README.md
@@ -168,6 +168,9 @@ extraction?: {
   category_batch_size?: number // Number of comments to classify in one batch process (default is 5)
 
 },
+embedding?: {
+  model?: string // model name for embedding step. supports "text-embedding-3-small" and "text-embedding-3-large". Defaults to "text-embedding-3-small"
+},
 clustering: {
   clusters?: number // number of clusters to generate (default to 8)
 }

--- a/scatter/README_ja.md
+++ b/scatter/README_ja.md
@@ -143,6 +143,9 @@ open http://localhost:8080/pipeline/outputs/my-project/report/
     } // argsに付与するカテゴリの定義。キーはカテゴリグループ名、値は各カテゴリの説明のオブジェクト。categoriesが存在する場合はLLMを用いたカテゴリ分類がextraction内部で実行される。
     category_batch_size?: number // 一度のバッチ処理で分類するコメントの数 (デフォルトは5)
   },
+  embedding?: {
+    model?: string // 埋め込みステップのためのモデル名。"text-embedding-3-small" と "text-embedding-3-large" をサポート。デフォルトは "text-embedding-3-small"
+  },
   clustering: {
     clusters?: number // 生成するクラスターの数（デフォルトは8）
   },

--- a/scatter/pipeline/configs/dummy-comments-japan-multi.json
+++ b/scatter/pipeline/configs/dummy-comments-japan-multi.json
@@ -22,6 +22,9 @@
       },
       "category_batch_size": 5
     },
+    "embedding": {
+      "model": "text-embedding-3-large"
+    },
     "clustering": {
       "clusters": 3
     },

--- a/scatter/pipeline/specs.json
+++ b/scatter/pipeline/specs.json
@@ -19,8 +19,11 @@
     "step": "embedding",
     "filename": "embeddings.pkl",
     "dependencies": {
-      "params": [],
+      "params": ["model"],
       "steps": ["extraction"]
+    },
+    "options": {
+      "model": "text-embedding-3-small"
     }
   },
   {


### PR DESCRIPTION
# 背景
* 利用する埋め込みモデルがtext-embedding-3-largeで固定されていた

# 実装内容
* 埋め込みモデルをconfigで選択できるようにした
  * `text-embedding-3-large` or `text-embedding-3-small` を選択可能
  * デフォルトでは `text-embedding-3-small` を採用
    * 精度が必要な場合はlargeを利用してもらう。
  * tttc本家ではada-002を採用しているが、`small` と次元数が同じでベンチマークの精度も低いため、こちらではサポートしていない