### PR TITLE
Fixes #20 - Optimize Fullscreen Menu

### DIFF
--- a/scatter/next-app/.eslintrc.json
+++ b/scatter/next-app/.eslintrc.json
@@ -7,6 +7,7 @@
     "import"
   ],
   "rules": {
+    "indent": ["error", 2, { "SwitchCase": 1 }],
     "quotes": ["error", "single"],
     "semi": ["error", "never"],
     "no-extra-semi": ["error"],

--- a/scatter/next-app/components/DesktopFullscreenFavorites.tsx
+++ b/scatter/next-app/components/DesktopFullscreenFavorites.tsx
@@ -15,14 +15,14 @@ type Props = {
 }
 
 export function DesktopFullscreenFavorites({
-                                             favorites,
-                                             removeFavorite,
-                                             clusters,
-                                             translator,
-                                             color,
-                                             onlyCluster,
-                                             onClose
-                                           }: Props) {
+  favorites,
+  removeFavorite,
+  clusters,
+  translator,
+  color,
+  onlyCluster,
+  onClose
+}: Props) {
   return (
     <div
       className="absolute top-0 right-0 w-[400px] p-4 bg-gray-100 overflow-y-auto z-10 h-full shadow-md"

--- a/scatter/next-app/components/DesktopFullscreenFavorites.tsx
+++ b/scatter/next-app/components/DesktopFullscreenFavorites.tsx
@@ -1,0 +1,86 @@
+import {BookmarkCheckIcon, XIcon} from 'lucide-react'
+import React from 'react'
+import {ColorFunc} from '@/hooks/useClusterColor'
+import {Translator} from '@/hooks/useTranslatorAndReplacements'
+import {Cluster, FavoritePoint} from '@/types'
+
+type Props = {
+  favorites: FavoritePoint[]
+  removeFavorite: (fav: FavoritePoint) => void
+  clusters: Cluster[]
+  translator: Translator
+  color: ColorFunc
+  onlyCluster?: string
+  onClose: () => void
+}
+
+export function DesktopFullscreenFavorites({
+                                             favorites,
+                                             removeFavorite,
+                                             clusters,
+                                             translator,
+                                             color,
+                                             onlyCluster,
+                                             onClose
+                                           }: Props) {
+  return (
+    <div
+      className="absolute top-0 right-0 w-[400px] p-4 bg-gray-100 overflow-y-auto z-10 h-full shadow-md"
+    >
+      <div className="flex justify-between items-center mb-4 h-[32px]">
+        <h2 className="text-md font-bold">
+          {translator.t('お気に入り一覧')}
+        </h2>
+        <button onClick={onClose}>
+          <XIcon/>
+        </button>
+      </div>
+      {favorites.length === 0 ? (
+        <p>{translator.t('お気に入りがありません')}</p>
+      ) : (
+        <ul>
+          {favorites.map((fav) => {
+            // クラスタ情報を取得
+            const cluster = clusters.find((c) => c.cluster_id === fav.cluster_id)
+            return (
+              <li
+                key={fav.arg_id}
+                className="mb-2 p-2 bg-white rounded shadow flex flex-col"
+              >
+                <div className="flex items-center justify-between">
+                  {/* クラスタラベル */}
+                  <h3
+                    className="font-semibold text-md"
+                    style={{
+                      color: cluster ? color(cluster.cluster_id, onlyCluster) : '#000',
+                    }}
+                  >
+                    {translator.t(cluster?.cluster || 'クラスタ')}
+                  </h3>
+
+                  {/* お気に入りボタン */}
+                  <button
+                    onClick={() => removeFavorite(fav)}
+                    className="text-amber-500 text-lg focus:outline-none ml-2"
+                  >
+                    <BookmarkCheckIcon/>
+                  </button>
+                </div>
+
+                {/* 引用部分を100文字に制限 */}
+                <p className="text-md text-gray-700 mt-1">
+                  {truncateText(fav.argument, 100)}
+                </p>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function truncateText(text: string, maxLength: number) {
+  if (text.length <= maxLength) return text
+  return text.slice(0, maxLength) + '...'
+}

--- a/scatter/next-app/components/DesktopFullscreenFilter.tsx
+++ b/scatter/next-app/components/DesktopFullscreenFilter.tsx
@@ -1,0 +1,135 @@
+import {XIcon} from 'lucide-react'
+import React from 'react'
+import {Translator} from '@/hooks/useTranslatorAndReplacements'
+import {Argument, PropertyMap} from '@/types'
+
+type Props = {
+  translator: Translator
+  onClose: () => void
+  highlightText: string
+  setHighlightText: React.Dispatch<React.SetStateAction<string>>
+  propertyMap: PropertyMap
+  propertyFilter: { [key: string]: string }
+  setPropertyFilter: React.Dispatch<React.SetStateAction<{ [key: string]: string }>>
+  dataHasVotes: boolean
+  minVotes: number
+  setMinVotes: React.Dispatch<React.SetStateAction<number>>
+  minConsensus: number
+  setMinConsensus: React.Dispatch<React.SetStateAction<number>>
+  voteFilter: {
+    total: number
+    filtered: number
+    filter: (arg: Argument) => boolean
+  }
+}
+
+export function DesktopFullscreenFilter(props: Props) {
+  const {t} = props.translator
+  return (
+    <div
+      className="absolute top-0 left-0 w-[400px] p-4 bg-gray-100 overflow-y-auto z-10 h-full shadow-md"
+    >
+      {/* Header */}
+      <div className="flex justify-between items-center mb-4 h-[32px]">
+        <h2 className="text-md font-bold">
+          {t('toolboxFilterSettings')}
+        </h2>
+        <button onClick={props.onClose}>
+          <XIcon/>
+        </button>
+      </div>
+      {/* Search */}
+      <input
+        type="text"
+        placeholder={t('検索')}
+        value={props.highlightText}
+        onChange={(e) => props.setHighlightText(e.target.value)}
+        className="w-full mb-2 p-2 border rounded"
+      />
+      <dl className={'mb-2'}>
+        {Object.entries(props.propertyMap).map(([propKey, propValues]) => {
+          const uniqueValues = Array.from(new Set(Object.values(propValues)))
+          uniqueValues.sort() // ABC順にソート
+          return (
+            <div key={propKey}>
+              <dt>{propKey}</dt>
+              <dd>
+                <select
+                  value={props.propertyFilter[propKey] ?? ''}
+                  onChange={(e) => {
+                    // propKeyごとの選択値を状態管理する必要あり
+                    props.setPropertyFilter((prev) => ({
+                      ...prev,
+                      [propKey]: e.target.value,
+                    }))
+                  }}
+                  className="border p-1 rounded w-full"
+                >
+                  <option value="">{t('(すべて)')}</option>
+                  {uniqueValues.map((val) => (
+                    <option key={val} value={val}>
+                      {val}
+                    </option>
+                  ))}
+                </select>
+              </dd>
+            </div>
+          )
+        })}
+      </dl>
+
+      {/* Votes */}
+      {props.dataHasVotes && (
+        <div>
+          <div className="flex justify-between">
+            <button className="inline-block text-left">
+              {t('Votes')} {'>'}{' '}
+              <span className="inline-block w-10">{props.minVotes}</span>
+            </button>
+            <input
+              className="inline-block w-[200px] mr-2"
+              id="min-votes-slider"
+              type="range"
+              min="0"
+              max="50"
+              value={props.minVotes}
+              onInput={(e) => {
+                props.setMinVotes(
+                  parseInt(
+                    (e.target as HTMLInputElement).value
+                  )
+                )
+              }}
+            />
+          </div>
+          <div className="flex justify-between">
+            <button className="inline-block text-left">
+              {t('Consensus')} {'>'}{' '}
+              <span className="inline-block w-10">{props.minConsensus}%</span>
+            </button>
+            <input
+              className="inline-block w-[200px] mr-2"
+              id="min-consensus-slider"
+              type="range"
+              min="50"
+              max="100"
+              value={props.minConsensus}
+              onInput={(e) => {
+                props.setMinConsensus(
+                  parseInt(
+                    (e.target as HTMLInputElement).value
+                  )
+                )
+              }}
+            />
+          </div>
+          <div className="text-sm opacity-70">
+            {t('Showing')} {props.voteFilter.filtered}/
+            {props.voteFilter.total} {t('arguments')}
+          </div>
+        </div>
+      )}
+
+    </div>
+  )
+}

--- a/scatter/next-app/components/DesktopFullscreenFilter.tsx
+++ b/scatter/next-app/components/DesktopFullscreenFilter.tsx
@@ -32,7 +32,7 @@ export function DesktopFullscreenFilter(props: Props) {
       {/* Header */}
       <div className="flex justify-between items-center mb-4 h-[32px]">
         <h2 className="text-md font-bold">
-          {t('toolboxFilterSettings')}
+          {t('toolsFilterSettings')}
         </h2>
         <button onClick={props.onClose}>
           <XIcon/>

--- a/scatter/next-app/components/DesktopFullscreenTools.tsx
+++ b/scatter/next-app/components/DesktopFullscreenTools.tsx
@@ -1,0 +1,73 @@
+import {
+  AtSignIcon,
+  BookMarkedIcon,
+  ChartPieIcon,
+  Minimize2Icon,
+  ScanSearchIcon,
+  SlidersHorizontalIcon,
+  TagIcon
+} from 'lucide-react'
+import React from 'react'
+import {Translator} from '@/hooks/useTranslatorAndReplacements'
+
+type Props = {
+  canFilter: boolean // !!propertyMap
+  zoomReset: boolean | (() => void)
+  translator: Translator
+  exitFullScreen: () => void // back
+  showSettings: boolean
+  setShowSettings: React.Dispatch<React.SetStateAction<boolean>>
+  showLabels: boolean
+  setShowLabels: React.Dispatch<React.SetStateAction<boolean>>
+  showTitle: boolean
+  setShowTitle: React.Dispatch<React.SetStateAction<boolean>>
+  showRatio: boolean
+  setShowRatio: React.Dispatch<React.SetStateAction<boolean>>
+  showFavorites: boolean
+  setShowFavorites: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+export function DesktopFullscreenTools(props: Props) {
+  const {t} = props.translator
+  return (
+    <div className="absolute top-0 w-full p-2" style={{backgroundColor: 'rgba(255, 255, 255, 0.5)'}}>
+      <div className={'flex justify-between items-center'}>
+        <div className={'flex'}>
+          {props.canFilter && (
+            <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => props.setShowSettings(x => !x)}>
+              <SlidersHorizontalIcon className={props.showSettings ? 'text-blue-500' : 'text-gray-500'}/>
+              <p className={'text-xs text-gray-700'}>{t('toolboxFilterSettings')}</p>
+            </button>
+          )}
+          <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => props.setShowLabels(x => !x)}>
+            <TagIcon className={props.showLabels ? 'text-blue-500' : 'text-gray-500'}/>
+            <p className={'text-xs text-gray-700'}>{t('toolboxDisplayLabels')}</p>
+          </button>
+          <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => props.setShowTitle(x => !x)}>
+            <AtSignIcon className={props.showTitle ? 'text-blue-500' : 'text-gray-500'}/>
+            <p className={'text-xs text-gray-700'}>{t('toolboxDisplayTitle')}</p>
+          </button>
+          <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => props.setShowRatio(x => !x)}>
+            <ChartPieIcon className={props.showRatio ? 'text-blue-500' : 'text-gray-500'}/>
+            <p className={'text-xs text-gray-700'}>{t('toolboxDisplayPercentage')}</p>
+          </button>
+          <button className="w-[80px] m-1 flex flex-col items-center"
+                  onClick={() => typeof props.zoomReset === 'function' && props.zoomReset()}>
+            <ScanSearchIcon className={props.zoomReset ? 'text-blue-500' : 'text-gray-500'}/>
+            <p className={'text-xs text-gray-700'}>{t('toolboxResetPosition')}</p>
+          </button>
+        </div>
+        <div className={'flex justify-between items-center'}>
+          <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => props.setShowFavorites(x => !x)}>
+            <BookMarkedIcon className={'text-gray-700'}/>
+            <p className={'text-xs text-gray-700'}>{t('toolboxDisplayFavorites')}</p>
+          </button>
+          <button className="w-[80px] m-1 flex flex-col items-center" onClick={props.exitFullScreen}>
+            <Minimize2Icon className={'text-gray-700'}/>
+            <p className={'text-xs text-gray-700'}>{t('toolboxExitFullScreen')}</p>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/scatter/next-app/components/DesktopFullscreenTools.tsx
+++ b/scatter/next-app/components/DesktopFullscreenTools.tsx
@@ -36,35 +36,35 @@ export function DesktopFullscreenTools(props: Props) {
           {props.canFilter && (
             <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => props.setShowSettings(x => !x)}>
               <SlidersHorizontalIcon className={props.showSettings ? 'text-blue-500' : 'text-gray-500'}/>
-              <p className={'text-xs text-gray-700'}>{t('toolboxFilterSettings')}</p>
+              <p className={'text-xs text-gray-700'}>{t('toolsFilterSettings')}</p>
             </button>
           )}
           <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => props.setShowLabels(x => !x)}>
             <TagIcon className={props.showLabels ? 'text-blue-500' : 'text-gray-500'}/>
-            <p className={'text-xs text-gray-700'}>{t('toolboxDisplayLabels')}</p>
+            <p className={'text-xs text-gray-700'}>{t('toolsDisplayLabels')}</p>
           </button>
           <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => props.setShowTitle(x => !x)}>
             <AtSignIcon className={props.showTitle ? 'text-blue-500' : 'text-gray-500'}/>
-            <p className={'text-xs text-gray-700'}>{t('toolboxDisplayTitle')}</p>
+            <p className={'text-xs text-gray-700'}>{t('toolsDisplayTitle')}</p>
           </button>
           <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => props.setShowRatio(x => !x)}>
             <ChartPieIcon className={props.showRatio ? 'text-blue-500' : 'text-gray-500'}/>
-            <p className={'text-xs text-gray-700'}>{t('toolboxDisplayPercentage')}</p>
+            <p className={'text-xs text-gray-700'}>{t('toolsDisplayPercentage')}</p>
           </button>
           <button className="w-[80px] m-1 flex flex-col items-center"
                   onClick={() => typeof props.zoomReset === 'function' && props.zoomReset()}>
             <ScanSearchIcon className={props.zoomReset ? 'text-blue-500' : 'text-gray-500'}/>
-            <p className={'text-xs text-gray-700'}>{t('toolboxResetPosition')}</p>
+            <p className={'text-xs text-gray-700'}>{t('toolsResetPosition')}</p>
           </button>
         </div>
         <div className={'flex justify-between items-center'}>
           <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => props.setShowFavorites(x => !x)}>
             <BookMarkedIcon className={'text-gray-700'}/>
-            <p className={'text-xs text-gray-700'}>{t('toolboxDisplayFavorites')}</p>
+            <p className={'text-xs text-gray-700'}>{t('toolsDisplayFavorites')}</p>
           </button>
           <button className="w-[80px] m-1 flex flex-col items-center" onClick={props.exitFullScreen}>
             <Minimize2Icon className={'text-gray-700'}/>
-            <p className={'text-xs text-gray-700'}>{t('toolboxExitFullScreen')}</p>
+            <p className={'text-xs text-gray-700'}>{t('toolsExitFullScreen')}</p>
           </button>
         </div>
       </div>

--- a/scatter/next-app/components/DesktopFullscreenTools.tsx
+++ b/scatter/next-app/components/DesktopFullscreenTools.tsx
@@ -52,7 +52,7 @@ export function DesktopFullscreenTools(props: Props) {
             <p className={'text-xs text-gray-700'}>{t('toolsDisplayPercentage')}</p>
           </button>
           <button className="w-[80px] m-1 flex flex-col items-center"
-                  onClick={() => typeof props.zoomReset === 'function' && props.zoomReset()}>
+            onClick={() => typeof props.zoomReset === 'function' && props.zoomReset()}>
             <ScanSearchIcon className={props.zoomReset ? 'text-blue-500' : 'text-gray-500'}/>
             <p className={'text-xs text-gray-700'}>{t('toolsResetPosition')}</p>
           </button>

--- a/scatter/next-app/components/DesktopMap.tsx
+++ b/scatter/next-app/components/DesktopMap.tsx
@@ -1,7 +1,14 @@
-import {IconProp} from '@fortawesome/fontawesome-svg-core'
-import {faBookmark as solidBookmark, faXmark} from '@fortawesome/free-solid-svg-icons'
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
 import {useGesture} from '@use-gesture/react'
+import {
+  AtSignIcon,
+  BookmarkCheckIcon,
+  BookMarkedIcon,
+  ChartPieIcon,
+  Minimize2Icon,
+  ScanSearchIcon, SlidersHorizontalIcon,
+  TagIcon,
+  XIcon
+} from 'lucide-react'
 import React, {useEffect, useRef, useState} from 'react'
 import CustomTitle from '@/components/CustomTitle'
 import Tooltip from '@/components/DesktopTooltip'
@@ -38,8 +45,6 @@ type MapProps = Result & {
   }
   propertyMap: PropertyMap
 }
-
-type PropertyFilter = { [key: string]: string }
 
 const truncateText = (text: string, maxLength: number) => {
   if (text.length <= maxLength) return text
@@ -162,39 +167,6 @@ function ClusterLabels(
   )
 }
 
-function PropertyFilter(propertyMap: PropertyMap,
-                        propertyFilter: PropertyFilter, setPropertyFilter: React.Dispatch<React.SetStateAction<PropertyFilter>>, t: any) {
-  return <><span className="m-2">{t('属性フィルタ')}</span>
-    {Object.entries(propertyMap).map(([propKey, propValues]) => {
-      const uniqueValues = Array.from(new Set(Object.values(propValues)))
-      uniqueValues.sort() // ABC順にソート
-
-      return (
-        <span key={propKey} className="mb-4">
-        <label className="m-2 font-semibold">{propKey}: </label>
-        <select
-          value={propertyFilter[propKey] ?? ''}
-          onChange={(e) => {
-            // propKeyごとの選択値を状態管理する必要あり
-            setPropertyFilter((prev) => ({
-              ...prev,
-              [propKey]: e.target.value,
-            }))
-          }}
-          className="border p-1 rounded"
-        >
-          <option value="">{t('(すべて)')}</option>
-          {uniqueValues.map((val) => (
-            <option key={val} value={val}>
-              {val}
-            </option>
-          ))}
-        </select>
-      </span>
-      )
-    })}</>
-}
-
 function DesktopMap(props: MapProps) {
   const {
     fullScreen = false,
@@ -264,6 +236,7 @@ function DesktopMap(props: MapProps) {
   const [showFavorites, setShowFavorites] = useState(false)
   const [showFilters, setShowFilters] = useState(false)
   const [showTitle, setShowTitle] = useState(false)
+  const [showSettings, setShowSettings] = useState(false)
 
   const totalArgs = clusters
     .map((c) => c.arguments.length)
@@ -627,45 +600,30 @@ function DesktopMap(props: MapProps) {
           {fullScreen && (
             <div className="absolute top-0 w-full p-2" style={{ backgroundColor: 'rgba(255, 255, 255, 0.5)' }}>
               <div className={'flex justify-between items-center'}>
-                <div>
-                  <button className="m-2 underline" onClick={back}>
-                    {t('Back to report')}
-                  </button>
-                  <button
-                    className="m-2 underline"
-                    onClick={() => setShowLabels(x => !x)}>
-                    {showLabels ? t('Hide labels') : t('Show labels')}
-                  </button>
-                  <button
-                    className="m-2 underline"
-                    onClick={() => setShowTitle(x => !x)}
-                  >
-                    {showTitle ? t('タイトルを非表示') : t('タイトルを表示')}
-                  </button>
-                  <button
-                    className="m-2 underline"
-                    onClick={() => setShowRatio(x => !x)}
-                  >
-                    {showRatio ? t('割合を非表示') : t('割合を表示')}
-                  </button>
-                  {zoom.reset && (
-                    <button
-                      className="m-2 underline"
-                      onClick={zoom.reset as any}
-                    >
-                      {t('Reset zoom')}
+                <div className={'flex'}>
+                  {propertyMap && (
+                    <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => setShowSettings(x => !x)}>
+                      <SlidersHorizontalIcon className={showSettings ? 'text-blue-500' : 'text-gray-500'}/>
+                      <p className={'text-xs text-gray-700'}>{t('toolboxFilterSettings')}</p>
                     </button>
                   )}
-                  <input
-                    type="text"
-                    placeholder={t('検索')}
-                    value={highlightText}
-                    onChange={(e) => setHighlightText(e.target.value)}
-                    className="w-20 mx-2 p-2 border rounded"
-                  />
-
-                  {/* PROPERTY FILTER */}
-                  {propertyMap && PropertyFilter(propertyMap, propertyFilter, setPropertyFilter, t)}
+                  <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => setShowLabels(x => !x)}>
+                    <TagIcon className={showLabels ? 'text-blue-500' : 'text-gray-500'}/>
+                    <p className={'text-xs text-gray-700'}>{t('toolboxDisplayLabels')}</p>
+                  </button>
+                  <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => setShowTitle(x => !x)}>
+                    <AtSignIcon className={showTitle ? 'text-blue-500' : 'text-gray-500'}/>
+                    <p className={'text-xs text-gray-700'}>{t('toolboxDisplayTitle')}</p>
+                  </button>
+                  <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => setShowRatio(x => !x)}>
+                    <ChartPieIcon className={showRatio ? 'text-blue-500' : 'text-gray-500'}/>
+                    <p className={'text-xs text-gray-700'}>{t('toolboxDisplayPercentage')}</p>
+                  </button>
+                  <button className="w-[80px] m-1 flex flex-col items-center"
+                          onClick={() => typeof zoom.reset === 'function' && zoom.reset()}>
+                    <ScanSearchIcon className={zoom.reset ? 'text-blue-500' : 'text-gray-500'}/>
+                    <p className={'text-xs text-gray-700'}>{t('toolboxResetPosition')}</p>
+                  </button>
 
                   {dataHasVotes && (
                     <button
@@ -733,18 +691,76 @@ function DesktopMap(props: MapProps) {
                     </div>
                   )}
                 </div>
-                <div>
-                  <button
-                    className="m-2 underline"
-                    onClick={() => setShowFavorites(x => !x)}
-                  >
-                    {showFavorites ? t('お気に入りを非表示') : t('お気に入りを表示')}
+                <div className={'flex justify-between items-center'}>
+                  <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => setShowFavorites(x => !x)}>
+                    <BookMarkedIcon className={'text-gray-700'}/>
+                    <p className={'text-xs text-gray-700'}>{t('toolboxDisplayFavorites')}</p>
+                  </button>
+                  <button className="w-[80px] m-1 flex flex-col items-center" onClick={back}>
+                    <Minimize2Icon className={'text-gray-700'}/>
+                    <p className={'text-xs text-gray-700'}>{t('toolboxExitFullScreen')}</p>
                   </button>
                 </div>
               </div>
             </div>
           )}
         </div>
+
+        {/* フィルター一覧 */}
+        {(fullScreen && propertyMap && showSettings) && (
+          <div
+            className="absolute top-0 left-0 w-[400px] p-4 bg-gray-100 overflow-y-auto z-10 h-full shadow-md"
+          >
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-md font-bold">
+                {translator.t('toolboxFilterSettings')}
+              </h2>
+              <button onClick={() => {
+                setShowSettings(!showSettings)
+              }}>
+                <XIcon/>
+              </button>
+            </div>
+            <input
+              type="text"
+              placeholder={t('検索')}
+              value={highlightText}
+              onChange={(e) => setHighlightText(e.target.value)}
+              className="w-full p-2 border rounded"
+            />
+            <dl>
+              {Object.entries(propertyMap).map(([propKey, propValues]) => {
+                const uniqueValues = Array.from(new Set(Object.values(propValues)))
+                uniqueValues.sort() // ABC順にソート
+                return (
+                  <div key={propKey}>
+                    <dt>{propKey}</dt>
+                    <dd>
+                      <select
+                        value={propertyFilter[propKey] ?? ''}
+                        onChange={(e) => {
+                          // propKeyごとの選択値を状態管理する必要あり
+                          setPropertyFilter((prev) => ({
+                            ...prev,
+                            [propKey]: e.target.value,
+                          }))
+                        }}
+                        className="border p-1 rounded w-full"
+                      >
+                        <option value="">{t('(すべて)')}</option>
+                        {uniqueValues.map((val) => (
+                          <option key={val} value={val}>
+                            {val}
+                          </option>
+                        ))}
+                      </select>
+                    </dd>
+                  </div>
+                )
+              })}
+            </dl>
+          </div>
+        )}
 
         {/* お気に入り一覧 */}
         {(fullScreen && showFavorites) && (
@@ -756,7 +772,7 @@ function DesktopMap(props: MapProps) {
                 {translator.t('お気に入り一覧')}
               </h2>
               <button onClick={() => {setShowFavorites(!showFavorites)}}>
-                <FontAwesomeIcon icon={faXmark as IconProp} size={'lg'} />
+                <XIcon />
               </button>
             </div>
             {favorites.length === 0 ? (
@@ -787,7 +803,7 @@ function DesktopMap(props: MapProps) {
                           onClick={() => toggleFavorite(fav)}
                           className="text-amber-500 text-lg focus:outline-none ml-2"
                         >
-                          <FontAwesomeIcon icon={solidBookmark as IconProp}/>
+                          <BookmarkCheckIcon />
                         </button>
                       </div>
 

--- a/scatter/next-app/components/DesktopMap.tsx
+++ b/scatter/next-app/components/DesktopMap.tsx
@@ -1,16 +1,9 @@
 import {useGesture} from '@use-gesture/react'
-import {
-  AtSignIcon,
-  BookmarkCheckIcon,
-  BookMarkedIcon,
-  ChartPieIcon,
-  Minimize2Icon,
-  ScanSearchIcon, SlidersHorizontalIcon,
-  TagIcon,
-  XIcon
-} from 'lucide-react'
 import React, {useEffect, useRef, useState} from 'react'
 import CustomTitle from '@/components/CustomTitle'
+import {DesktopFullscreenFavorites} from '@/components/DesktopFullscreenFavorites'
+import {DesktopFullscreenFilter} from '@/components/DesktopFullscreenFilter'
+import {DesktopFullscreenTools} from '@/components/DesktopFullscreenTools'
 import Tooltip from '@/components/DesktopTooltip'
 import useAutoResize from '@/hooks/useAutoResize'
 import {ColorFunc} from '@/hooks/useClusterColor'
@@ -44,11 +37,6 @@ type MapProps = Result & {
     question?: string
   }
   propertyMap: PropertyMap
-}
-
-const truncateText = (text: string, maxLength: number) => {
-  if (text.length <= maxLength) return text
-  return text.slice(0, maxLength) + '...'
 }
 
 function DotCircles(
@@ -234,9 +222,8 @@ function DesktopMap(props: MapProps) {
   const [showLabels, setShowLabels] = useState(true)
   const [showRatio, setShowRatio] = useState(false)
   const [showFavorites, setShowFavorites] = useState(false)
-  const [showFilters, setShowFilters] = useState(false)
   const [showTitle, setShowTitle] = useState(false)
-  const [showSettings, setShowSettings] = useState(false)
+  const [showFilterSettings, setShowFilterSettings] = useState(false)
 
   const totalArgs = clusters
     .map((c) => c.arguments.length)
@@ -596,227 +583,57 @@ function DesktopMap(props: MapProps) {
               }}
             />
           )}
-          {/* BACK BUTTON と その他のボタン */}
-          {fullScreen && (
-            <div className="absolute top-0 w-full p-2" style={{ backgroundColor: 'rgba(255, 255, 255, 0.5)' }}>
-              <div className={'flex justify-between items-center'}>
-                <div className={'flex'}>
-                  {propertyMap && (
-                    <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => setShowSettings(x => !x)}>
-                      <SlidersHorizontalIcon className={showSettings ? 'text-blue-500' : 'text-gray-500'}/>
-                      <p className={'text-xs text-gray-700'}>{t('toolboxFilterSettings')}</p>
-                    </button>
-                  )}
-                  <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => setShowLabels(x => !x)}>
-                    <TagIcon className={showLabels ? 'text-blue-500' : 'text-gray-500'}/>
-                    <p className={'text-xs text-gray-700'}>{t('toolboxDisplayLabels')}</p>
-                  </button>
-                  <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => setShowTitle(x => !x)}>
-                    <AtSignIcon className={showTitle ? 'text-blue-500' : 'text-gray-500'}/>
-                    <p className={'text-xs text-gray-700'}>{t('toolboxDisplayTitle')}</p>
-                  </button>
-                  <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => setShowRatio(x => !x)}>
-                    <ChartPieIcon className={showRatio ? 'text-blue-500' : 'text-gray-500'}/>
-                    <p className={'text-xs text-gray-700'}>{t('toolboxDisplayPercentage')}</p>
-                  </button>
-                  <button className="w-[80px] m-1 flex flex-col items-center"
-                          onClick={() => typeof zoom.reset === 'function' && zoom.reset()}>
-                    <ScanSearchIcon className={zoom.reset ? 'text-blue-500' : 'text-gray-500'}/>
-                    <p className={'text-xs text-gray-700'}>{t('toolboxResetPosition')}</p>
-                  </button>
-
-                  {dataHasVotes && (
-                    <button
-                      className="m-2 underline"
-                      onClick={() => {
-                        setShowFilters((x) => !x)
-                      }}
-                    >
-                      {showFilters ? t('Hide filters') : t('Show filters')}
-                    </button>
-                  )}
-                  {/* FILTERS */}
-                  {showFilters && (
-                    <div className="absolute w-[400px] top-12 left-2 p-2 border bg-white rounded leading-4">
-                      <div className="flex justify-between">
-                        <button className="inline-block m-2 text-left">
-                          {t('Votes')} {'>'}{' '}
-                          <span className="inline-block w-10">
-                        {minVotes}
-                      </span>
-                        </button>
-                        <input
-                          className="inline-block w-[200px] mr-2"
-                          id="min-votes-slider"
-                          type="range"
-                          min="0"
-                          max="50"
-                          value={minVotes}
-                          onInput={(e) => {
-                            setMinVotes(
-                              parseInt(
-                                (e.target as HTMLInputElement).value
-                              )
-                            )
-                          }}
-                        />
-                      </div>
-                      <div className="flex justify-between">
-                        <button className="inline-block m-2 text-left">
-                          {t('Consensus')} {'>'}{' '}
-                          <span className="inline-block w-10">
-                        {minConsensus}%
-                      </span>
-                        </button>
-                        <input
-                          className="inline-block w-[200px] mr-2"
-                          id="min-consensus-slider"
-                          type="range"
-                          min="50"
-                          max="100"
-                          value={minConsensus}
-                          onInput={(e) => {
-                            setMinConsensus(
-                              parseInt(
-                                (e.target as HTMLInputElement).value
-                              )
-                            )
-                          }}
-                        />
-                      </div>
-                      <div className="text-sm ml-2 mt-2 opacity-70">
-                        {t('Showing')} {voteFilter.filtered}/
-                        {voteFilter.total} {t('arguments')}
-                      </div>
-                    </div>
-                  )}
-                </div>
-                <div className={'flex justify-between items-center'}>
-                  <button className="w-[80px] m-1 flex flex-col items-center" onClick={() => setShowFavorites(x => !x)}>
-                    <BookMarkedIcon className={'text-gray-700'}/>
-                    <p className={'text-xs text-gray-700'}>{t('toolboxDisplayFavorites')}</p>
-                  </button>
-                  <button className="w-[80px] m-1 flex flex-col items-center" onClick={back}>
-                    <Minimize2Icon className={'text-gray-700'}/>
-                    <p className={'text-xs text-gray-700'}>{t('toolboxExitFullScreen')}</p>
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
         </div>
-
-        {/* フィルター一覧 */}
-        {(fullScreen && propertyMap && showSettings) && (
-          <div
-            className="absolute top-0 left-0 w-[400px] p-4 bg-gray-100 overflow-y-auto z-10 h-full shadow-md"
-          >
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="text-md font-bold">
-                {translator.t('toolboxFilterSettings')}
-              </h2>
-              <button onClick={() => {
-                setShowSettings(!showSettings)
-              }}>
-                <XIcon/>
-              </button>
-            </div>
-            <input
-              type="text"
-              placeholder={t('検索')}
-              value={highlightText}
-              onChange={(e) => setHighlightText(e.target.value)}
-              className="w-full p-2 border rounded"
-            />
-            <dl>
-              {Object.entries(propertyMap).map(([propKey, propValues]) => {
-                const uniqueValues = Array.from(new Set(Object.values(propValues)))
-                uniqueValues.sort() // ABC順にソート
-                return (
-                  <div key={propKey}>
-                    <dt>{propKey}</dt>
-                    <dd>
-                      <select
-                        value={propertyFilter[propKey] ?? ''}
-                        onChange={(e) => {
-                          // propKeyごとの選択値を状態管理する必要あり
-                          setPropertyFilter((prev) => ({
-                            ...prev,
-                            [propKey]: e.target.value,
-                          }))
-                        }}
-                        className="border p-1 rounded w-full"
-                      >
-                        <option value="">{t('(すべて)')}</option>
-                        {uniqueValues.map((val) => (
-                          <option key={val} value={val}>
-                            {val}
-                          </option>
-                        ))}
-                      </select>
-                    </dd>
-                  </div>
-                )
-              })}
-            </dl>
-          </div>
+        {/* 全画面メニュー */}
+        {fullScreen && (
+          <DesktopFullscreenTools
+            canFilter={!!propertyMap}
+            zoomReset={zoom.reset}
+            translator={translator}
+            exitFullScreen={back!}
+            showSettings={showFilterSettings}
+            setShowSettings={setShowFilterSettings}
+            showLabels={showLabels}
+            setShowLabels={setShowLabels}
+            showTitle={showTitle}
+            setShowTitle={setShowTitle}
+            showRatio={showRatio}
+            setShowRatio={setShowRatio}
+            showFavorites={showFavorites}
+            setShowFavorites={setShowFavorites}
+          />
         )}
-
+        {/* フィルター一覧 */}
+        {(fullScreen && propertyMap && showFilterSettings) && (
+          <DesktopFullscreenFilter
+            translator={translator}
+            onClose={() => setShowFilterSettings(false)}
+            highlightText={highlightText}
+            setHighlightText={setHighlightText}
+            propertyMap={propertyMap}
+            propertyFilter={propertyFilter}
+            setPropertyFilter={setPropertyFilter}
+            dataHasVotes={dataHasVotes}
+            minVotes={minVotes}
+            setMinVotes={setMinVotes}
+            minConsensus={minConsensus}
+            setMinConsensus={setMinConsensus}
+            voteFilter={voteFilter}
+          />
+        )}
         {/* お気に入り一覧 */}
         {(fullScreen && showFavorites) && (
-          <div
-            className="absolute top-0 right-0 w-[400px] p-4 bg-gray-100 overflow-y-auto z-10 h-full shadow-md"
-          >
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="text-md font-bold">
-                {translator.t('お気に入り一覧')}
-              </h2>
-              <button onClick={() => {setShowFavorites(!showFavorites)}}>
-                <XIcon />
-              </button>
-            </div>
-            {favorites.length === 0 ? (
-              <p>{translator.t('お気に入りがありません')}</p>
-            ) : (
-              <ul>
-                {favorites.map((fav) => {
-                  // クラスタ情報を取得
-                  const cluster = clusters.find((c) => c.cluster_id === fav.cluster_id)
-                  return (
-                    <li
-                      key={fav.arg_id}
-                      className="mb-2 p-2 bg-white rounded shadow flex flex-col"
-                    >
-                      <div className="flex items-center justify-between">
-                        {/* クラスタラベル */}
-                        <h3
-                          className="font-semibold text-md"
-                          style={{
-                            color: cluster ? color(cluster.cluster_id, onlyCluster) : '#000',
-                          }}
-                        >
-                          {translator.t(cluster?.cluster || 'クラスタ')}
-                        </h3>
-
-                        {/* お気に入りボタン */}
-                        <button
-                          onClick={() => toggleFavorite(fav)}
-                          className="text-amber-500 text-lg focus:outline-none ml-2"
-                        >
-                          <BookmarkCheckIcon />
-                        </button>
-                      </div>
-
-                      {/* 引用部分を100文字に制限 */}
-                      <p className="text-md text-gray-700 mt-1">
-                        {truncateText(fav.argument, 100)}
-                      </p>
-                    </li>
-                  )
-                })}
-              </ul>
-            )}
-          </div>
+          <DesktopFullscreenFavorites
+            favorites={favorites}
+            clusters={clusters}
+            translator={translator}
+            color={color}
+            onlyCluster={onlyCluster}
+            removeFavorite={(fav) => {
+              setFavorites((prev) => prev.filter((item) => item.arg_id !== fav.arg_id))
+            }}
+            onClose={() => setShowFavorites(false)}
+          />
         )}
       </div>
     </>

--- a/scatter/next-app/components/DesktopTooltip.tsx
+++ b/scatter/next-app/components/DesktopTooltip.tsx
@@ -85,7 +85,7 @@ function Tooltip(props: TooltipProps) {
         {/* ツールチップの内容 */}
         <div style={{display: 'flex', alignItems: 'center'}}>
           <h3 style={{color: colorFunc(point.cluster_id), margin: 0}}
-              className="text-base sm:text-base md:text-base font-bold">
+            className="text-base sm:text-base md:text-base font-bold">
             {/* ラベルを大きくする */}
             {translator.t(point.cluster)}
           </h3>

--- a/scatter/next-app/components/DesktopTooltip.tsx
+++ b/scatter/next-app/components/DesktopTooltip.tsx
@@ -1,7 +1,4 @@
-import {IconProp} from '@fortawesome/fontawesome-svg-core'
-import {faBookmark as regularBookmark} from '@fortawesome/free-regular-svg-icons'
-import {faBookmark as solidBookmark} from '@fortawesome/free-solid-svg-icons'
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
+import {BookmarkCheckIcon, BookmarkIcon} from 'lucide-react'
 import React from 'react'
 import {ColorFunc} from '@/hooks/useClusterColor'
 import {Translator} from '@/hooks/useTranslatorAndReplacements'
@@ -95,13 +92,13 @@ function Tooltip(props: TooltipProps) {
           {/* お気に入りボタン */}
           <button
             onClick={() => onToggleFavorite()}
-            className="text-amber-500 text-lg focus:outline-none ml-2"
+            className="text-gray-300 text-lg focus:outline-none ml-2"
             aria-label={
               isFavorite ? t('お気に入りから削除') : t('お気に入りに追加')
             }
             style={{marginLeft: '8px'}}
           >
-            <FontAwesomeIcon icon={isFavorite ? solidBookmark as IconProp : regularBookmark as IconProp}/>
+            {isFavorite ? <BookmarkCheckIcon className={'text-amber-500'} /> : <BookmarkIcon />}
           </button>
         </div>
         <p className="text-sm sm:text-sm md:text-md mt-2">{point.argument}</p>

--- a/scatter/next-app/components/DesktopTooltip.tsx
+++ b/scatter/next-app/components/DesktopTooltip.tsx
@@ -98,7 +98,7 @@ function Tooltip(props: TooltipProps) {
             }
             style={{marginLeft: '8px'}}
           >
-            {isFavorite ? <BookmarkCheckIcon className={'text-amber-500'} /> : <BookmarkIcon />}
+            {isFavorite ? <BookmarkCheckIcon className={'text-amber-500'}/> : <BookmarkIcon/>}
           </button>
         </div>
         <p className="text-sm sm:text-sm md:text-md mt-2">{point.argument}</p>

--- a/scatter/next-app/components/Header.tsx
+++ b/scatter/next-app/components/Header.tsx
@@ -23,7 +23,7 @@ const Header = (props: HeaderProps) => {
           onClick={() => setLangIndex(i)}
         >
           <img className="w-5 inline-block leading-5 pb-[4px] hover:shadow-2xl shadow-white"
-               src={`https://purecatamphetamine.github.io/country-flag-icons/3x2/${lang.flag}.svg`} alt=""/>
+            src={`https://purecatamphetamine.github.io/country-flag-icons/3x2/${lang.flag}.svg`} alt=""/>
           {/* {t(lang.name)} */}
         </button>)}
       </div>}

--- a/scatter/next-app/components/MobileMap.tsx
+++ b/scatter/next-app/components/MobileMap.tsx
@@ -144,37 +144,37 @@ function MobileMap(props: MapProps) {
           showLabels &&
           !zoom.dragging &&
           !isTouchDevice() && (
-            <div>
-              {clusters.map((cluster) => (
-                <div
-                  className={`absolute opacity-90 bg-white p-2 max-w-lg rounded-lg pointer-events-none select-none transition-opacity duration-300 font-bold ${isTouch ? 'text-base' : 'text-2xl'}`}
-                  key={cluster.cluster_id}
-                  style={{
-                    transform: 'translate(-50%, -50%)',
-                    left: zoom.zoomX(
-                      scaleX(
-                        mean(cluster.arguments.map(({x}) => x))
-                      )
-                    ),
-                    top: zoom.zoomY(
-                      scaleY(
-                        mean(cluster.arguments.map(({y}) => y))
-                      )
-                    ),
-                    color: color(cluster.cluster_id, onlyCluster),
-                    opacity:
+          <div>
+            {clusters.map((cluster) => (
+              <div
+                className={`absolute opacity-90 bg-white p-2 max-w-lg rounded-lg pointer-events-none select-none transition-opacity duration-300 font-bold ${isTouch ? 'text-base' : 'text-2xl'}`}
+                key={cluster.cluster_id}
+                style={{
+                  transform: 'translate(-50%, -50%)',
+                  left: zoom.zoomX(
+                    scaleX(
+                      mean(cluster.arguments.map(({x}) => x))
+                    )
+                  ),
+                  top: zoom.zoomY(
+                    scaleY(
+                      mean(cluster.arguments.map(({y}) => y))
+                    )
+                  ),
+                  color: color(cluster.cluster_id, onlyCluster),
+                  opacity:
                       expanded
                         ? 0.3
                         : tooltip?.cluster_id === cluster.cluster_id
                           ? 0
                           : 0.85,
-                  }}
-                >
-                  {t(cluster.cluster)}
-                </div>
-              ))}
-            </div>
-          )}
+                }}
+              >
+                {t(cluster.cluster)}
+              </div>
+            ))}
+          </div>
+        )}
         {/* TOOLTIP */}
         {tooltip && (
           <Tooltip

--- a/scatter/next-app/components/MobileTooltip.tsx
+++ b/scatter/next-app/components/MobileTooltip.tsx
@@ -15,13 +15,13 @@ type TooltipProps = {
 }
 
 const Tooltip = ({
-                   point,
-                   dimensions,
-                   expanded,
-                   zoom,
-                   fullScreen,
-                   translator,
-                 }: TooltipProps) => {
+  point,
+  dimensions,
+  expanded,
+  zoom,
+  fullScreen,
+  translator,
+}: TooltipProps) => {
   const {scaleX, scaleY, width, height} = dimensions
   const {zoomX, zoomY} = zoom
   const {t} = translator

--- a/scatter/next-app/components/Outline.tsx
+++ b/scatter/next-app/components/Outline.tsx
@@ -23,7 +23,7 @@ const Outline = ({clusters, translator}: Props) => {
       <Section name={t('Introduction')!} target="introduction"/>
       <Section name={t('Clusters')!} target="clusters"/>
       {clusters.map((cluster, i) => <Section small key={i} name={t(cluster.cluster)!}
-                                             target={'cluster-' + cluster.cluster_id}
+        target={'cluster-' + cluster.cluster_id}
       />)}
       <Section name={t('Appendix')!} target="appendix"/>
     </div>

--- a/scatter/next-app/components/VideoLink.tsx
+++ b/scatter/next-app/components/VideoLink.tsx
@@ -21,7 +21,7 @@ const VideoLink = ({video, timestamp, interview, showThumbnail, showVideo}: Vide
     {showThumbnail &&
       <img className="mt-2" width="320" height="240" src={`https://vumbnail.com/${videoId}.jpg`} alt=""/>}
     {showVideo && <iframe src={`https://player.vimeo.com/video/${videoId}#t=${totalSeconds}s`} width="320" height="240"
-                          allow="autoplay; fullscreen; picture-in-picture"></iframe>}
+      allow="autoplay; fullscreen; picture-in-picture"></iframe>}
   </div>
 }
 

--- a/scatter/next-app/hooks/useTranslatorAndReplacements.ts
+++ b/scatter/next-app/hooks/useTranslatorAndReplacements.ts
@@ -48,13 +48,13 @@ const JapaneseUI: { [key: string]: string } = {
   overview: '概要',
   exitFullScreen: '全画面を終了',
   // 全画面表示ツール
-  toolboxExitFullScreen: '全画面を終了',
-  toolboxDisplayLabels: 'ラベル表示',
-  toolboxDisplayTitle: 'タイトル表示',
-  toolboxDisplayPercentage: '割合表示',
-  toolboxResetPosition: '初期位置に戻す',
-  toolboxDisplayFavorites: 'お気に入り一覧',
-  toolboxFilterSettings: 'フィルター設定',
+  toolsExitFullScreen: '全画面を終了',
+  toolsDisplayLabels: 'ラベル表示',
+  toolsDisplayTitle: 'タイトル表示',
+  toolsDisplayPercentage: '割合表示',
+  toolsResetPosition: '初期位置に戻す',
+  toolsDisplayFavorites: 'お気に入り一覧',
+  toolsFilterSettings: 'フィルター設定',
 }
 
 const useTranslatorAndReplacements = (

--- a/scatter/next-app/hooks/useTranslatorAndReplacements.ts
+++ b/scatter/next-app/hooks/useTranslatorAndReplacements.ts
@@ -46,6 +46,15 @@ const JapaneseUI: { [key: string]: string } = {
   labelling: 'ラベリング',
   takeaways: 'まとめ',
   overview: '概要',
+  exitFullScreen: '全画面を終了',
+  // 全画面表示ツール
+  toolboxExitFullScreen: '全画面を終了',
+  toolboxDisplayLabels: 'ラベル表示',
+  toolboxDisplayTitle: 'タイトル表示',
+  toolboxDisplayPercentage: '割合表示',
+  toolboxResetPosition: '初期位置に戻す',
+  toolboxDisplayFavorites: 'お気に入り一覧',
+  toolboxFilterSettings: 'フィルター設定',
 }
 
 const useTranslatorAndReplacements = (

--- a/scatter/next-app/package-lock.json
+++ b/scatter/next-app/package-lock.json
@@ -8,13 +8,12 @@
       "name": "next-app",
       "version": "0.1.0",
       "dependencies": {
-        "@fortawesome/free-regular-svg-icons": "^6.7.2",
-        "@fortawesome/free-solid-svg-icons": "^6.7.2",
-        "@fortawesome/react-fontawesome": "^0.2.2",
         "@use-gesture/react": "^10.3.1",
         "@visx/voronoi": "^3.12.0",
         "@visx/zoom": "^3.12.0",
+        "classnames": "^2.5.1",
         "diff": "^5.1.0",
+        "lucide-react": "^0.469.0",
         "next": "^14.2.15",
         "opencc-js": "^1.0.5",
         "react": "^18",
@@ -136,81 +135,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
-      "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
-      "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
-      "peer": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-regular-svg-icons": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz",
-      "integrity": "sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==",
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.7.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-regular-svg-icons/node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
-      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
-      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.7.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons/node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
-      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
-      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1536,9 +1460,10 @@
       }
     },
     "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -3781,6 +3706,15 @@
         "node": "14 || >=16.14"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.469.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
+      "integrity": "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
@@ -5875,59 +5809,6 @@
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true
     },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
-      "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
-      "peer": true
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
-      "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
-      "peer": true,
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.6.0"
-      }
-    },
-    "@fortawesome/free-regular-svg-icons": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz",
-      "integrity": "sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.7.2"
-      },
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": {
-          "version": "6.7.2",
-          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
-          "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg=="
-        }
-      }
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
-      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.7.2"
-      },
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": {
-          "version": "6.7.2",
-          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
-          "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg=="
-        }
-      }
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
-      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
-      "requires": {
-        "prop-types": "^15.8.1"
-      }
-    },
     "@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -6782,9 +6663,9 @@
       }
     },
     "classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "client-only": {
       "version": "0.0.1",
@@ -8339,6 +8220,12 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
       "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
       "dev": true
+    },
+    "lucide-react": {
+      "version": "0.469.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
+      "integrity": "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==",
+      "requires": {}
     },
     "math-intrinsics": {
       "version": "1.0.0",

--- a/scatter/next-app/package.json
+++ b/scatter/next-app/package.json
@@ -11,13 +11,12 @@
     "upgrade": "npx npm-check-updates --interactive"
   },
   "dependencies": {
-    "@fortawesome/free-regular-svg-icons": "^6.7.2",
-    "@fortawesome/free-solid-svg-icons": "^6.7.2",
-    "@fortawesome/react-fontawesome": "^0.2.2",
     "@use-gesture/react": "^10.3.1",
     "@visx/voronoi": "^3.12.0",
     "@visx/zoom": "^3.12.0",
+    "classnames": "^2.5.1",
     "diff": "^5.1.0",
+    "lucide-react": "^0.469.0",
     "next": "^14.2.15",
     "opencc-js": "^1.0.5",
     "react": "^18",


### PR DESCRIPTION
#20 全画面メニューのUI修正です
<img width="1134" alt="Screenshot 2024-12-26 at 16 50 44" src="https://github.com/user-attachments/assets/6818ab98-b8aa-49e5-bb44-4bc74aa6df9e" />

主な修正内容
- lucide icons の導入
- 上部メニュのコンポーネント化
- フィルターのコンポーネント化
- お気に入りのコンポーネント化

備考
できればマップの上に重ねるのではなく、上左右に表示できると尚良い
マップの width, height 計算を修正する必要があったのでこのPRでは見送っている