### PR TITLE
docs: improve README clarity by adding project context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Talk to the City
 
-Talk to the City（[TTTC](https://github.com/AIObjectives/talk-to-the-city-reports)）のscatterについて、幾つかの改良を行ったレポジトリです。
+Talk to the City（[TTTC](https://github.com/AIObjectives/talk-to-the-city-reports)）は市民の声を可視化するプロジェクトです。このレポジトリはTTTCのscatter機能について、幾つかの改良を行ったものです。
 
 
 ## Talk to the City Reports


### PR DESCRIPTION
This PR improves the README by:

- Adding more context about what TTTC (Talk to the City) is
- Making the sentence structure clearer by splitting it into two parts

These changes help readers better understand the purpose of the project at first glance.